### PR TITLE
Add categories to desktop files

### DIFF
--- a/desktop/dsnote.desktop
+++ b/desktop/dsnote.desktop
@@ -1,5 +1,6 @@
 [Desktop Entry]
 Type=Application
+Categories=Utility;Office;Audio;AudioVideo;TextEditor;KDE;Qt;
 Icon=dsnote
 Exec=dsnote %F
 Name=Speech Note

--- a/sfos/harbour-dsnote.desktop
+++ b/sfos/harbour-dsnote.desktop
@@ -1,5 +1,6 @@
 [Desktop Entry]
 Type=Application
+Categories=Utility;Office;Audio;AudioVideo;TextEditor;KDE;Qt;
 Icon=harbour-dsnote
 Exec=harbour-dsnote --app %F
 Name=Speech Note


### PR DESCRIPTION
When installing the Flatpak on my Linux Mint computer, Speech Note got categorised under "Other", like so:

![speech-note-desktop-categorisation](https://github.com/mkiol/dsnote/assets/45298929/f364b654-c5fb-41ef-91e2-c26a3f8f2924)

I therefore decided to add some application categories to the `.desktop` files in this repo, adhering to the Freedesktop specifications for [required](https://specifications.freedesktop.org/menu-spec/latest/apa.html) and [additional](https://specifications.freedesktop.org/menu-spec/latest/apas02.html) application categories. If I need to change the categories listed in any way (e.g. if there's anything I'm missing or any debatable additions), please let me know.

The reasoning for including `AudioVideo` alongside `Audio` in the categories is listed in the Freedesktop specification for the required categories, of which `Audio` is one of them: `Desktop entry must include AudioVideo as well`