### PR TITLE
Add "Translation" to desktop file categories

### DIFF
--- a/desktop/dsnote.desktop
+++ b/desktop/dsnote.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Categories=Utility;Office;Audio;AudioVideo;TextEditor;KDE;Qt;
+Categories=Utility;Office;Audio;AudioVideo;TextEditor;Translation;KDE;Qt;
 Icon=dsnote
 Exec=dsnote %F
 Name=Speech Note

--- a/sfos/harbour-dsnote.desktop
+++ b/sfos/harbour-dsnote.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Categories=Utility;Office;Audio;AudioVideo;TextEditor;KDE;Qt;
+Categories=Utility;Office;Audio;AudioVideo;TextEditor;Translation;KDE;Qt;
 Icon=harbour-dsnote
 Exec=harbour-dsnote --app %F
 Name=Speech Note


### PR DESCRIPTION
I somehow missed that Speech Note had translation features while working on #64 so, [since `Translation` is one of the additional Freedesktop categories](https://specifications.freedesktop.org/menu-spec/latest/apas02.html), I decided to correct my mistake now.