### PR TITLE
Fix CUDA toolchain detection for Arch builds

### DIFF
--- a/arch/git/PKGBUILD
+++ b/arch/git/PKGBUILD
@@ -113,10 +113,52 @@ build() {
   FULL_BUILD=true
 
   if [[ "${CARCH}" == "x86_64" ]]; then
-    pacman -Qi cuda &> /dev/null && HAS_CUDA=true || HAS_CUDA=false
+    CUDA_ROOT="${CUDAToolkit_ROOT:-${CUDA_PATH:-${CUDA_HOME:-}}}"
+    CUDA_NVCC=
+    if [[ -n "${CUDACXX:-}" ]] && [[ "${CUDACXX}" != *" "* ]]; then
+      if [[ "${CUDACXX}" == */* ]] && [[ -x "${CUDACXX}" ]]; then
+        CUDA_NVCC="${CUDACXX}"
+      elif [[ "${CUDACXX}" != */* ]]; then
+        CUDA_NVCC="$(command -v "${CUDACXX}" || true)"
+      fi
+    fi
+    if [[ -n "${CUDA_ROOT}" ]] && [[ -x "${CUDA_ROOT}/bin/nvcc" ]]; then
+      CUDA_NVCC="${CUDA_ROOT}/bin/nvcc"
+    fi
+    if [[ -z "${CUDA_NVCC}" ]]; then
+      CUDA_NVCC="$(command -v nvcc || true)"
+    fi
+    if [[ -z "${CUDA_ROOT}" ]] && [[ -n "${CUDA_NVCC}" ]]; then
+      CUDA_ROOT="$(dirname "$(dirname "${CUDA_NVCC}")")"
+    fi
+    if [[ -z "${CUDA_NVCC}" ]] && [[ -x /opt/cuda/bin/nvcc ]]; then
+      CUDA_ROOT=/opt/cuda
+      CUDA_NVCC=/opt/cuda/bin/nvcc
+    fi
+
+    pacman -Qi cuda &> /dev/null && [[ -n "${CUDA_NVCC}" ]] && HAS_CUDA=true || HAS_CUDA=false
 
     if [[ $HAS_CUDA = true ]] && [[ $FULL_BUILD = true ]]; then
-      CMAKE+=" -DBUILD_WHISPERCPP_CUBLAS=ON -DCMAKE_CUDA_ARCHITECTURES=native"
+      export CUDA_PATH="${CUDA_ROOT}"
+      export CUDAToolkit_ROOT="${CUDA_ROOT}"
+      export PATH="$(dirname "${CUDA_NVCC}"):$PATH"
+      CUDA_CMAKE="-DBUILD_WHISPERCPP_CUBLAS=ON \
+        -DCMAKE_CUDA_ARCHITECTURES=native \
+        -DCUDAToolkit_ROOT=${CUDA_ROOT}"
+      if [[ -z "${CUDACXX:-}" ]]; then
+        CUDA_CMAKE+=" -DCMAKE_CUDA_COMPILER=${CUDA_NVCC}"
+      fi
+      if [[ -n "${CUDAHOSTCXX:-}" ]] && [[ -x "${CUDAHOSTCXX}" ]]; then
+        CUDA_CMAKE+=" -DCMAKE_CUDA_HOST_COMPILER=${CUDAHOSTCXX}"
+      elif [[ -n "${NVCC_CCBIN:-}" ]] && [[ -x "${NVCC_CCBIN}" ]]; then
+        export CUDAHOSTCXX="${NVCC_CCBIN}"
+        CUDA_CMAKE+=" -DCMAKE_CUDA_HOST_COMPILER=${NVCC_CCBIN}"
+      elif [[ -x /usr/bin/g++-15 ]]; then
+        export NVCC_CCBIN=/usr/bin/g++-15
+        export CUDAHOSTCXX=/usr/bin/g++-15
+        CUDA_CMAKE+=" -DCMAKE_CUDA_HOST_COMPILER=/usr/bin/g++-15"
+      fi
+      CMAKE+=" ${CUDA_CMAKE}"
       export NVCC_APPEND_FLAGS="-std=c++17 --compress-mode=size --split-compile=0 -Wno-deprecated-gpu-targets"
     fi
   fi

--- a/arch/release/PKGBUILD
+++ b/arch/release/PKGBUILD
@@ -111,10 +111,52 @@ build() {
   FULL_BUILD=true
 
   if [[ "${CARCH}" == "x86_64" ]]; then
-    pacman -Qi cuda &> /dev/null && HAS_CUDA=true || HAS_CUDA=false
+    CUDA_ROOT="${CUDAToolkit_ROOT:-${CUDA_PATH:-${CUDA_HOME:-}}}"
+    CUDA_NVCC=
+    if [[ -n "${CUDACXX:-}" ]] && [[ "${CUDACXX}" != *" "* ]]; then
+      if [[ "${CUDACXX}" == */* ]] && [[ -x "${CUDACXX}" ]]; then
+        CUDA_NVCC="${CUDACXX}"
+      elif [[ "${CUDACXX}" != */* ]]; then
+        CUDA_NVCC="$(command -v "${CUDACXX}" || true)"
+      fi
+    fi
+    if [[ -n "${CUDA_ROOT}" ]] && [[ -x "${CUDA_ROOT}/bin/nvcc" ]]; then
+      CUDA_NVCC="${CUDA_ROOT}/bin/nvcc"
+    fi
+    if [[ -z "${CUDA_NVCC}" ]]; then
+      CUDA_NVCC="$(command -v nvcc || true)"
+    fi
+    if [[ -z "${CUDA_ROOT}" ]] && [[ -n "${CUDA_NVCC}" ]]; then
+      CUDA_ROOT="$(dirname "$(dirname "${CUDA_NVCC}")")"
+    fi
+    if [[ -z "${CUDA_NVCC}" ]] && [[ -x /opt/cuda/bin/nvcc ]]; then
+      CUDA_ROOT=/opt/cuda
+      CUDA_NVCC=/opt/cuda/bin/nvcc
+    fi
+
+    pacman -Qi cuda &> /dev/null && [[ -n "${CUDA_NVCC}" ]] && HAS_CUDA=true || HAS_CUDA=false
 
     if [[ $HAS_CUDA = true ]] && [[ $FULL_BUILD = true ]]; then
-      CMAKE+=" -DBUILD_WHISPERCPP_CUBLAS=ON -DCMAKE_CUDA_ARCHITECTURES=native"
+      export CUDA_PATH="${CUDA_ROOT}"
+      export CUDAToolkit_ROOT="${CUDA_ROOT}"
+      export PATH="$(dirname "${CUDA_NVCC}"):$PATH"
+      CUDA_CMAKE="-DBUILD_WHISPERCPP_CUBLAS=ON \
+        -DCMAKE_CUDA_ARCHITECTURES=native \
+        -DCUDAToolkit_ROOT=${CUDA_ROOT}"
+      if [[ -z "${CUDACXX:-}" ]]; then
+        CUDA_CMAKE+=" -DCMAKE_CUDA_COMPILER=${CUDA_NVCC}"
+      fi
+      if [[ -n "${CUDAHOSTCXX:-}" ]] && [[ -x "${CUDAHOSTCXX}" ]]; then
+        CUDA_CMAKE+=" -DCMAKE_CUDA_HOST_COMPILER=${CUDAHOSTCXX}"
+      elif [[ -n "${NVCC_CCBIN:-}" ]] && [[ -x "${NVCC_CCBIN}" ]]; then
+        export CUDAHOSTCXX="${NVCC_CCBIN}"
+        CUDA_CMAKE+=" -DCMAKE_CUDA_HOST_COMPILER=${NVCC_CCBIN}"
+      elif [[ -x /usr/bin/g++-15 ]]; then
+        export NVCC_CCBIN=/usr/bin/g++-15
+        export CUDAHOSTCXX=/usr/bin/g++-15
+        CUDA_CMAKE+=" -DCMAKE_CUDA_HOST_COMPILER=/usr/bin/g++-15"
+      fi
+      CMAKE+=" ${CUDA_CMAKE}"
       export NVCC_APPEND_FLAGS="-std=c++17 --compress-mode=size --split-compile=0 -Wno-deprecated-gpu-targets"
     fi
   fi
@@ -134,4 +176,3 @@ package() {
   cd build
   make DESTDIR="$pkgdir" install
 }
-

--- a/cmake/whispercpp.cmake
+++ b/cmake/whispercpp.cmake
@@ -95,6 +95,12 @@ if(BUILD_WHISPERCPP_CUBLAS)
     if (NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
         set(CMAKE_CUDA_ARCHITECTURES 50 52 53 60 61 62 70 72 75 80 86 87 89 90 100)
     endif()
+    set(whispercpp_cuda_cmake_args)
+    foreach(cuda_arg CUDAToolkit_ROOT CMAKE_CUDA_COMPILER CMAKE_CUDA_HOST_COMPILER)
+        if(DEFINED ${cuda_arg})
+            list(APPEND whispercpp_cuda_cmake_args -D${cuda_arg}=${${cuda_arg}})
+        endif()
+    endforeach()
     list(JOIN CMAKE_CUDA_ARCHITECTURES "\\\\\\\\\\;" CUDA_ARCHS_STRING)
     ExternalProject_Add(whispercppcublas
         SOURCE_DIR ${external_dir}/whispercppcublas
@@ -113,6 +119,8 @@ if(BUILD_WHISPERCPP_CUBLAS)
             -DCMAKE_INSTALL_LIBDIR=lib
             -DGGML_NATIVE=OFF
             -DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES:STRING=${CUDA_ARCHS_STRING}
+            ${whispercpp_cuda_cmake_args}
+            -DCMAKE_CUDA_STANDARD=17 -DCMAKE_CUDA_STANDARD_REQUIRED=ON
             -DGGML_AVX=ON -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=ON
             -DBUILD_SHARED_LIBS=ON
             -DWHISPER_BUILD_TESTS=OFF -DWHISPER_BUILD_EXAMPLES=OFF


### PR DESCRIPTION
## Summary

Fix CUDA-enabled Arch builds by making the CUDA toolkit/compiler discovery explicit and by
propagating CUDA toolchain settings into the nested `whisper.cpp` CMake build.

This changes:

- `arch/git/PKGBUILD` and `arch/release/PKGBUILD`
  - discover `nvcc` from `CUDACXX`, `CUDAToolkit_ROOT`, `CUDA_PATH`, `CUDA_HOME`, `PATH`, and finally the Arch
    package fallback `/opt/cuda/bin/nvcc`;
  - export `CUDA_PATH`, `CUDAToolkit_ROOT`, and the directory containing `nvcc` before enabling
    `BUILD_WHISPERCPP_CUBLAS`;
  - pass `CUDAToolkit_ROOT`, `CMAKE_CUDA_COMPILER`, and, when available,
    `CMAKE_CUDA_HOST_COMPILER`;
  - honor user-provided `CUDAHOSTCXX` / `NVCC_CCBIN` before falling back to Arch's `g++-15`.
- `cmake/whispercpp.cmake`
  - forwards CUDA toolkit/compiler settings to the `whispercppcublas` `ExternalProject`;
  - sets `CMAKE_CUDA_STANDARD=17` for the nested CUDA build.

## Problem

AUR package `dsnote-git` currently enables `BUILD_WHISPERCPP_CUBLAS` on Arch when the `cuda` package is installed:

```bash
pacman -Qi cuda &> /dev/null && HAS_CUDA=true || HAS_CUDA=false
```

That check is not sufficient for a non-interactive package build. Arch installs CUDA under `/opt/cuda`, and the
CUDA package's profile script adds `/opt/cuda/bin` to `PATH` and sets `NVCC_CCBIN=/usr/bin/g++-15`. Package build
environments are not guaranteed to have that profile state loaded.

The result is that `BUILD_WHISPERCPP_CUBLAS=ON` can be enabled while the nested `whisper.cpp` CMake configure step
cannot find `nvcc`:

```text
CUDAToolkit_NVCC_EXECUTABLE:FILEPATH=CUDAToolkit_NVCC_EXECUTABLE-NOTFOUND
```

On systems where `nvcc` is found, CUDA 13.x / CCCL also requires C++17 for CUDA sources. The top-level project uses
C++17, but the nested `whisper.cpp` `ExternalProject` did not receive an explicit CUDA standard. This can fail later
during CUDA compilation with:

```text
CUB requires at least C++17
libcu++ requires at least C++ 17
Thrust requires at least C++17
```

## Why this follows upstream/toolchain behavior

CMake documents CUDA toolkit discovery in this order: the enabled CUDA compiler, `CMAKE_CUDA_COMPILER` / `CUDACXX`,
`CUDAToolkit_ROOT`, `CUDA_PATH`, then `PATH`, with platform defaults only after that. See:

- https://cmake.org/cmake/help/latest/module/FindCUDAToolkit.html
- https://cmake.org/cmake/help/latest/envvar/CUDACXX.html

CMake also documents `CUDAHOSTCXX` as the preferred host compiler input for CUDA compilation, which is cached as
`CMAKE_CUDA_HOST_COMPILER`:

- https://cmake.org/cmake/help/latest/envvar/CUDAHOSTCXX.html
- https://cmake.org/cmake/help/latest/variable/CMAKE_CUDA_HOST_COMPILER.html

NVIDIA's Linux installation guide says CUDA post-install setup must put the toolkit `bin` directory in `PATH`, and its
FAQ explicitly points to missing `PATH` setup when `nvcc` is not found:

- https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#post-installation-actions
- https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#why-do-i-see-nvcc-no-such-file-or-directory-when-i-try-to-build-a-cuda-application

The Arch `cuda` package matches that model: it installs the toolkit under `/opt/cuda`, ships `/etc/profile.d/cuda.sh`
with `CUDA_PATH=/opt/cuda`, adds `/opt/cuda/bin` to `PATH`, and sets `NVCC_CCBIN=/usr/bin/g++-15`.

- https://gitlab.archlinux.org/archlinux/packaging/packages/cuda/-/raw/main/cuda.sh
- https://gitlab.archlinux.org/archlinux/packaging/packages/cuda/-/blob/main/PKGBUILD

## Why this is not only a local setup issue

The current package logic enables CUDA based only on package presence. That works only if the build environment already
has the CUDA profile loaded. A clean AUR helper / makepkg environment can have `cuda` installed but still not expose
`nvcc` through `PATH`.

This fix keeps user-configured CUDA locations working (`CUDACXX`, `CUDAToolkit_ROOT`, `CUDA_PATH`, `CUDA_HOME`, `PATH`)
and uses `/opt/cuda` only as the Arch-package fallback. It does not require all systems to install CUDA in `/opt/cuda`.

## Verification

On Arch/CachyOS with:

- `cuda 13.3.1`
- `gcc15`
- `cmake 4.3.4`

I verified a clean CMake build of the CUDA `ExternalProject` path:

```bash
cmake -S <source-dir> -B <build-dir> \
  -DWITH_DESKTOP=ON \
  -DWITH_SFOS=OFF \
  -DWITH_PY=OFF \
  -DWITH_TESTS=OFF \
  -DDOWNLOAD_LIBSTT=OFF \
  -DBUILD_OPENBLAS=OFF \
  -DBUILD_VOSK=OFF \
  -DBUILD_BERGAMOT=OFF \
  -DBUILD_RHVOICE=OFF \
  -DBUILD_RHVOICE_MODULE=OFF \
  -DBUILD_WHISPERCPP_VULKAN=OFF \
  -DBUILD_WHISPERCPP_CUBLAS=ON \
  -DCUDAToolkit_ROOT=/opt/cuda \
  -DCMAKE_CUDA_COMPILER=/opt/cuda/bin/nvcc \
  -DCMAKE_CUDA_HOST_COMPILER=/usr/bin/g++-15 \
  -DCMAKE_CUDA_ARCHITECTURES=native

cmake --build <build-dir> --target whispercppcublas -- -j2
```

The generated nested configure command includes:

```text
-DCUDAToolkit_ROOT=/opt/cuda
-DCMAKE_CUDA_COMPILER=/opt/cuda/bin/nvcc
-DCMAKE_CUDA_HOST_COMPILER=/usr/bin/g++-15
-DCMAKE_CUDA_STANDARD=17
-DCMAKE_CUDA_STANDARD_REQUIRED=ON
```

The build completed successfully:

```text
[100%] Built target whispercppcublas
```
